### PR TITLE
Feature/copy associations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
 
 
     <!-- Test -->
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-all</artifactId>
+          <version>1.9.5</version>
+       </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/src/main/scala/org/idio/dbpedia/spotlight/IdioCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/IdioCandidateMapStore.scala
@@ -20,7 +20,7 @@ class IdioCandidateMapStore(val pathtoFolder:String, val resStore:MemoryResource
   * It looks if the given candidateID is inside the candidate array.
   * if it is not it will add it
   * */
-  def addOrCreate(surfaceFormID:Int, candidateID:Int){
+  def addOrCreate(surfaceFormID:Int, candidateID:Int, candidateCounts:Int){
     // try to get it, create the candidate array in case it doesnt exist
     try{
       this.candidateMap.candidates(surfaceFormID)
@@ -28,7 +28,7 @@ class IdioCandidateMapStore(val pathtoFolder:String, val resStore:MemoryResource
       case e:Exception =>{
          println("\tcreating candidate map array for "+surfaceFormID)
          var candidates:Array[Int] =Array(candidateID)
-         var counts:Array[Int] = Array(1)
+         var counts:Array[Int] = Array(candidateCounts)
          this.createCandidateMapForSurfaceForm(surfaceFormID, candidates, counts)
         println("\tcandidates")
         for(candidate <- this.candidateMap.candidates(surfaceFormID)){
@@ -44,7 +44,7 @@ class IdioCandidateMapStore(val pathtoFolder:String, val resStore:MemoryResource
       case e:Exception =>{
         println("\tcreating candidate map array for "+surfaceFormID)
         this.candidateMap.candidates(surfaceFormID) = Array[Int](candidateID)
-        this.candidateMap.candidateCounts(surfaceFormID) = Array[Int](1)
+        this.candidateMap.candidateCounts(surfaceFormID) = Array[Int](candidateCounts)
         println("\tcandidates")
         for(candidate <- this.candidateMap.candidates(surfaceFormID)){
           println("\t"+candidate)
@@ -56,7 +56,7 @@ class IdioCandidateMapStore(val pathtoFolder:String, val resStore:MemoryResource
     // if the candidate array exist, then check if the candidate Topic is inside
     if (!this.checkCandidateInSFCandidates(surfaceFormID, candidateID)){
       println("\tadding the candidate("+candidateID+") to candidates of "+surfaceFormID)
-      this.addNewCandidateToSF(surfaceFormID, candidateID, 1)
+      this.addNewCandidateToSF(surfaceFormID, candidateID, candidateCounts)
     }
 
   }
@@ -70,6 +70,18 @@ class IdioCandidateMapStore(val pathtoFolder:String, val resStore:MemoryResource
   def createCandidateMapForSurfaceForm(surfaceFormID:Int, listOfCandidates:Array[Int], listOfCounts:Array[Int]){
     this.candidateMap.candidates = Array concat(this.candidateMap.candidates, Array(listOfCandidates))
     this.candidateMap.candidateCounts =  Array concat(this.candidateMap.candidateCounts, Array(listOfCounts))
+  }
+
+  /*
+* returns the AVG candidate counts for a given SF
+* This value is used when creating a new association between a SF and a Topic
+* */
+  def getAVGSupportForSF(surfaceFormID:Int):Int = {
+    val candidateCounts = this.candidateMap.candidateCounts(surfaceFormID)
+    if  (candidateCounts.isInstanceOf[Array[Short]]){
+      return (candidateCounts.sum  / candidateCounts.size.toDouble).toInt
+    }
+    return 0
   }
 
   /*

--- a/src/main/scala/org/idio/dbpedia/spotlight/IdioCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/IdioCandidateMapStore.scala
@@ -86,7 +86,7 @@ class IdioCandidateMapStore(var candidateMap:MemoryCandidateMapStore,val pathtoF
 * */
   def getAVGSupportForSF(surfaceFormID:Int):Int = {
     val candidateCounts = this.candidateMap.candidateCounts(surfaceFormID)
-    if  (candidateCounts.isInstanceOf[Array[Short]]){
+    if  (candidateCounts.isInstanceOf[Array[Int]]){
       return (candidateCounts.sum  / candidateCounts.size.toDouble).toInt
     }
     return 0

--- a/src/main/scala/org/idio/dbpedia/spotlight/IdioCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/IdioCandidateMapStore.scala
@@ -9,10 +9,17 @@ import java.io.{File, FileInputStream}
 import Array.concat
 import org.dbpedia.spotlight.model.{Candidate, SurfaceForm}
 
-class IdioCandidateMapStore(val pathtoFolder:String, val resStore:MemoryResourceStore){
+class IdioCandidateMapStore(var candidateMap:MemoryCandidateMapStore,val pathtoFolder:String, val resStore:MemoryResourceStore){
 
 
-  var candidateMap:MemoryCandidateMapStore = MemoryStore.loadCandidateMapStore(new FileInputStream(new File(pathtoFolder,"candmap.mem")), resStore)
+
+  def this(pathtoFolder:String, resStore:MemoryResourceStore){
+    this(MemoryStore.loadCandidateMapStore(new FileInputStream(new File(pathtoFolder,"candmap.mem")), resStore), pathtoFolder, resStore)
+  }
+
+  def this(candidateMap:MemoryCandidateMapStore, resStore:MemoryResourceStore){
+    this(candidateMap, "",resStore)
+  }
 
   /*
   * Tries to get the candidate array for the given surfaceForm.
@@ -139,15 +146,15 @@ class IdioCandidateMapStore(val pathtoFolder:String, val resStore:MemoryResource
 
     // add the candidates associated to the destinationSF but not to the sourceSF
     val setOfCandidatesTopics:collection.immutable.Set[Int] = collection.immutable.Set[Int](newDestinationCandidates:_*)
-    val currentDestinationCandidates = this.candidateMap.getCandidates(destinationSurfaceForm)
+    val currentDestinationCandidates =  this.candidateMap.candidates(destinationSurfaceForm.id).zip(this.candidateMap.candidateCounts(destinationSurfaceForm.id))
 
 
-    currentDestinationCandidates.foreach{ candidate:Candidate =>
+    currentDestinationCandidates.foreach{ case (topicId, count)  =>
 
       // if candidate is not already in the new candidate list then add it
-      if (setOfCandidatesTopics.contains(candidate.resource.id)){
-        newDestinationCandidates = newDestinationCandidates :+ candidate.resource.id
-        newDestinationCandidatesCounts = newDestinationCandidatesCounts :+ candidate.support
+      if (!setOfCandidatesTopics.contains(topicId)){
+        newDestinationCandidates = newDestinationCandidates :+ topicId
+        newDestinationCandidatesCounts = newDestinationCandidatesCounts :+ count
       }
 
     }

--- a/src/main/scala/org/idio/dbpedia/spotlight/IdioSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/IdioSpotlightModel.scala
@@ -361,6 +361,20 @@ class IdioSpotlightModel(val pathToFolder:String){
   }
 
   /*
+    takes all topic candidates for the surfaceForm1
+    and associate them to surfaceForm2.
+    Assumes that both SurfaceForms exists in the model
+  */
+  def copyCandidates(surfaceTextSource:String, surfaceTextDestination:String){
+
+    val sourceSurfaceForm = this.idioSurfaceFormStore.sfStore.getSurfaceForm(surfaceTextSource)
+    val destinySurfaceForm = this.idioSurfaceFormStore.sfStore.getSurfaceForm(surfaceTextDestination)
+
+    this.idioCandidateMapStore.copyCandidates(sourceSurfaceForm, destinySurfaceForm)
+
+  }
+
+  /*
   * Removes the link between a SF and a Dbpedia Topic
   * */
   def removeAssociation(surfaceFormText:String, dbpediaURI:String){

--- a/src/main/scala/org/idio/dbpedia/spotlight/IdioSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/IdioSpotlightModel.scala
@@ -132,6 +132,10 @@ class IdioSpotlightModel(val pathToFolder:String){
     val surfaceFormID:Int = this.idioSurfaceFormStore.getAddSurfaceForm(surfaceFormText)
     this.idioSurfaceFormStore.boostCountsIfNeeded(surfaceFormID)
     var defaultSupportForDbpediaResource:Int = 11
+    val defaultSupportForCandidate:Int = 30
+
+    val avgSupportCandidate = math.max(defaultSupportForCandidate, this.idioCandidateMapStore.getAVGSupportForSF(surfaceFormID)) + 10
+
 
     // calculate the default support value based on the current support for the candidates for the given SF
     try{
@@ -154,7 +158,7 @@ class IdioSpotlightModel(val pathToFolder:String){
     val dbpediaResourceID:Int = this.idioDbpediaResourceStore.getAddDbpediaResource(candidateURI, defaultSupportForDbpediaResource, types)
 
     //update the candidate Store
-    this.idioCandidateMapStore.addOrCreate(surfaceFormID, dbpediaResourceID)
+    this.idioCandidateMapStore.addOrCreate(surfaceFormID, dbpediaResourceID, avgSupportCandidate)
 
     return (surfaceFormID, dbpediaResourceID)
 

--- a/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
@@ -110,6 +110,19 @@ object Main{
           }
         }
 
+        /*
+          takes all topic candidates for the surfaceForm1
+          and associate them to surfaceForm2.
+          Assumes that both SurfaceForms exists in the model
+        */
+        case "copy-candidates" =>{
+          val surfaceFormTextSource = args(2)
+          val surfaceFormTextDestiny = args(3)
+
+          spotlightModelReader.copyCandidates(surfaceFormTextSource, surfaceFormTextDestiny)
+          spotlightModelReader.exportModels(pathToModelFolder)
+        }
+
         //checks existence of Dbpedia's Ids, SF, and links between SF's and Dbpedia's ids.
         case "remove-sf-topic-association" =>{
           val pathToFileWithSFTopicPairs = args(2)

--- a/src/test/scala/CandidateStoreTest.scala
+++ b/src/test/scala/CandidateStoreTest.scala
@@ -1,0 +1,49 @@
+/**
+ * Created by dav009 on 24/04/2014.
+ */
+
+import org.dbpedia.spotlight.db.memory.{MemoryResourceStore, MemoryCandidateMapStore}
+import org.dbpedia.spotlight.model.SurfaceForm
+import org.idio.dbpedia.spotlight.IdioCandidateMapStore
+import org.scalatest.mock.MockitoSugar.mock
+import org.junit.Test
+import org.junit.Assert._
+
+class CandidateStoreTest {
+
+  @Test
+  def testCopyCandidates(){
+
+    // mock needed objects
+    val candidateMap:MemoryCandidateMapStore = new MemoryCandidateMapStore()
+    val resStore:MemoryResourceStore = mock[MemoryResourceStore]
+
+    //mock candidate store
+    candidateMap.candidates = Array[Array[Int]]( Array[Int](1, 2, 3), Array[Int](3, 5) )
+    candidateMap.candidateCounts= Array[Array[Int]]( Array[Int](50, 1, 100),  Array[Int](14, 55))
+
+    val sourceSurfaceForm =  new SurfaceForm("sf1", 0, 100, 200)
+    val destinySurfaceForm = new  SurfaceForm("sf2", 1, 50, 200)
+
+
+    var idioCandidateMapStore:IdioCandidateMapStore = new IdioCandidateMapStore(candidateMap, "", resStore)
+
+    // test copy candidates
+    idioCandidateMapStore.copyCandidates(sourceSurfaceForm, destinySurfaceForm)
+
+    val expectedCandidateCounts = collection.immutable.Map[Int, Int](1->50, 2->1, 3->100, 5->55)
+
+    //check the candidate topics set
+    val candidateTopicsForDestinySurfaceForm = idioCandidateMapStore.candidateMap.candidates(1)
+    assertTrue(collection.immutable.Set[Int](candidateTopicsForDestinySurfaceForm:_*)==expectedCandidateCounts.keySet)
+
+    //check the candidate counts
+    candidateTopicsForDestinySurfaceForm.zip(candidateMap.candidateCounts(1)).foreach{ case (topicKey, counts)=>
+      assertTrue(expectedCandidateCounts(topicKey) == counts)
+    }
+
+
+  }
+
+
+}


### PR DESCRIPTION
We had a case in which we wanted to have all the candidate topics of a surface form associated with a different surface form.

Previously when we had similar cases we would just create a file with the associations we wanted to create. The problem with this approach is that the original `candidate counts` are lost. this  loss affects the final spot if the number of candidate topics for a single `SF` is long.

So this PR introduces:
- A way to copy candidates from sourceSurfaceForm  to destinationSurfaceForm, this copies the candidates and their counts. (added the command `copy-candidates`)
- (A fix I had in the new branch) when a new candidate topic is added to a surfaceForm in the standard way, the `candidate count` value will be the average of the `candidate counts` for the selected surfaceForm
- A refactor of the `idioCandidateStore`'s constructor, so that unit-tests could be added.
- [x] @tgalery 
- [x] rolands muffin
