### PR TITLE
Automatically getting spotlight's Dependencies - Update pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ We also recommend using [IntelliJ](http://www.jetbrains.com/idea/), for editing 
 for instructions on how to set up a project.
 
 - [Compiling](#compiling)
-    - [Compiling Dbpedia Spotlight](#compiling-dbpedia-spotlight)
     - [Compiling Idio's Dbpedia Model Editor](#compiling-idios-dbpedia-model-editor)
     - [Importing Project](#importing-project)
 - [Editing a model](#editing-a-model)
@@ -38,36 +37,22 @@ for instructions on how to set up a project.
 
 ## Compiling
 
-We assume that you have the correct versions of Java and Scala, also make sure you have `mvn` in your system.
+We assume that you have the correct versions of Java and mvn in your system.
+
 The language models consume a lot of computational resources, so in these instructions we use the model for 
 Turkish (located in the `tr` folder). Feel free to play with other languages, if you have a big machine.
 
-### Compiling Dbpedia Spotlight
-
-DBpedia Spotlight's jar is one of the dependencies. These steps will guide you on how to compile spotlight
-
-1. clone `https://github.com/dbpedia-spotlight/dbpedia-spotlight`
-2. compile dbpedia spotlight: 
-  - `mvn package`
-
-after this step there should be a `dbpedia-spotlight-0.6-jar-with-dependencies.jar` in the `./dist/target` folder.
 
 ### Compiling Idio's Dbpedia Model Editor
 
 1. Clone this repo
-2. go to the repo's folder and do:
-
-  ```
-  mvn install:install-file -Dfile=path_to_spotlight_jar/dbpedia-spotlight-0.6-jar-with-dependencies.jar -DgroupId=org.dbpedia -DartifactId=spotlight -Dversion=0.6 -Dpackaging=jar
-  ```
-3. do `mvn compile`
-4. do `mvn package`
-5. call
+2. go to the repo's folder
+3. do `mvn package`
+4. call
 
 ```
 java -Xmx4000M -jar  target/idio-spotlight-model-0.1.0-jar-with-dependencies.jar explore path-to-turkish/tr/model/
 ```
-
 
 ## Importing Project
 1. Get IntelliJ

--- a/pom.xml
+++ b/pom.xml
@@ -148,4 +148,12 @@
 
     </plugins>
   </build>
+
+  <repositories>
+      <repository>
+          <id>idio-spotlight-releases-repository</id>
+          <url>https://bytebucket.org/idio/mvn-repo/raw/master/releases</url>
+      </repository>
+  </repositories>
+
 </project>


### PR DESCRIPTION
This changes the pom so that the main dependency (Spotlight's jar) is installed in mvn automatically when compiling.
- Avoids the hassle of getting the spotlight code, compiling it, and then manually installing the jar.
- Project should know how to compile itself

I created a public git-repo on bitbucket: https://bitbucket.org/idio/mvn-repo to serve as maven repo. The main reason for picking Bitbucket is that it has no limits on the file sizes (jars are a few hundred megs)
- [x] big Farouk
- [x] mac Thiago
