### PR TITLE
Feature/code clean up 0.7 Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,31 +386,6 @@ In order to use it:
 
 
 
-## Practical tips for updating a model
-
-Given that the models are quite big (2 GB compressed), downloading, modifying and uploading them would be very
- time consuming from your local machine. Plus, the operations require a lot of ram, so you better boot a dev instance, and do the changes from there.
- Here's a list of steps.
-
-1. Create the new instance:
-`knife ec2 server create -r "role[spotlight]" -I ami-6d3f9704 -G default -x ubuntu --node-name "dev-spotlight" --environment "development" -f m2.xlarge --availability-zone us-east-1d --secret-file path/to/secret/file`
-
-2. ssh into the new instance and install dependencies:
-`sudo apt-get install openjdk-6-jdk maven scala unzip`
-
-3. Clone the dbpedia model editor repo:
-`git clone git@github.com:idio/spotlight-model-editor.git`
-
-4. compile ```
-cd dbpedia-model-editor
-mvn package ```
-
-5. You can now use the model editor for a variety of tasks, for example, to remove SFs Topics associations stored in tab separated file, you can run (we assume the model is located in `/mnt/share/spotlight/`). 
-`sh target/bin/model-editor association remove-association /mnt/share/spotlight/en/model ~/remove_associations`
-The command would re-export the model, so you can just zip and upload the file to S3 to be used.
-
-6. Write the changes you made into a changelog, so we can duplicate them from scratch if needed [need to decide where to store changes] .
-
 ## License
 
 Copyright 2014 Idio

--- a/README.md
+++ b/README.md
@@ -280,6 +280,22 @@ example:
 sh target/bin/model-editor association remove /mnt/share/spotlight/en/model /path/to/file/file_with_associations
 ```
 
+### FSA
+
+#### Checking if a SF is spottable via FSA
+
+- **command**: `fsa`
+- **subcommand**: `find`
+- **arg1**: `pathToSpotlightModel/model`
+- **arg2**: piped separated list of surface forms
+- **result**: the FSA spots for each surface forms
+
+
+example:
+```
+sh target/bin/model-editor fsa find /mnt/share/spotlight/en/model Nintendo\ Wii\|barack
+```
+
 ### Updating Model From File
 When updating the model with lots of `SF`, `Topics` and `Context Words` best is to do it from a file.
 each line of the file should follow the format:

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
 
  -->
 
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.idio</groupId>
@@ -72,7 +71,7 @@
     <dependency>
       <groupId>org.dbpedia</groupId>
       <artifactId>spotlight</artifactId>
-      <version>0.6</version>
+      <version>0.7</version>
       <!--
         License: Apache Software License, Version 2.0
        -->

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -403,14 +403,19 @@ class CustomSpotlightModel(val pathToFolder: String) {
   def getStatsForSFInLowercaseSf(surfaceFormText: String){
     println("Looking in lowercase SF store.....")
     val (counts, candidatesUpperSF) = this.customSurfaceFormStore.findInLowerCaseSurfaceForm(surfaceFormText)
-    println("-------------------------------")
-    println(surfaceFormText)
-    println("\tcounts:" + counts.getOrElse(0))
-    println("")
-    println("candidates in uppercase SurfaceForm Store: ")
-    for (candidate <- candidatesUpperSF.getOrElse(Array[String]())) {
-      println("\t"+ candidate)
+    if(candidatesUpperSF.isDefined){
+        println("-------------------------------")
+        println(surfaceFormText)
+        println("\tcounts:" + counts.getOrElse(0))
+        println("")
+        println("candidates in uppercase SurfaceForm Store: ")
+        for (candidate <- candidatesUpperSF.getOrElse(Array[String]())) {
+          println("\t" + candidate)
+        }
+    }else{
+      println("NOT FOUND")
     }
+
   }
 
   /*

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -401,13 +401,13 @@ class CustomSpotlightModel(val pathToFolder: String) {
 
   // Print the stats of a surface form in the lowercase surface form store
   def getStatsForSFInLowercaseSf(surfaceFormText: String){
+    println("Looking in lowercase SF store.....")
     val (counts, candidatesUpperSF) = this.customSurfaceFormStore.findInLowerCaseSurfaceForm(surfaceFormText)
     println("-------------------------------")
     println(surfaceFormText)
     println("\tcounts:" + counts.getOrElse(0))
-    println("\tSURFACE FORM IN LOWERCASE STORE")
     println("")
-    println("candidates")
+    println("candidates in uppercase SurfaceForm Store: ")
     for (candidate <- candidatesUpperSF.getOrElse(Array[String]())) {
       println("\t"+ candidate)
     }

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -24,16 +24,20 @@ import org.dbpedia.spotlight.model.{ Candidate, TokenType, OntologyType }
 import org.dbpedia.spotlight.db.memory.MemoryStore
 import java.io.File
 import java.io.{ FileNotFoundException, FileInputStream }
-import java.util.Properties
+import java.util.{Locale, Properties}
 import collection.mutable.HashMap
 import scala.collection.mutable.HashSet
 import java.io.PrintWriter
 import scala.collection.JavaConverters._
 import org.idio.dbpedia.spotlight.stores._
+import org.dbpedia.spotlight.db.model.{Stemmer, TextTokenizer}
+import org.dbpedia.spotlight.db.tokenize.LanguageIndependentTokenizer
+import org.dbpedia.spotlight.db.stem.SnowballStemmer
+import org.dbpedia.spotlight.db.FSASpotter
 
 object Store extends Enumeration {
   type Store = Value
-  val SurfaceStore, CandidateStore, ResourceStore, ContextStore, TokenStore = Value
+  val SurfaceStore, CandidateStore, ResourceStore, ContextStore, TokenStore, QuantiziedStore = Value
 }
 
 class CustomSpotlightModel(val pathToFolder: String) {
@@ -50,9 +54,21 @@ class CustomSpotlightModel(val pathToFolder: String) {
    Allowing to load only the files which are needed as opposed to the whole model.
   */
   //load the Stores
+
+  lazy val customQuantizedCountStore: CustomQuantiziedCountStore = try{
+    usedStores.add(Store.QuantiziedStore)
+    new CustomQuantiziedCountStore(pathToFolder)
+  }catch{
+    case ex: FileNotFoundException =>{
+      println(ex.getMessage)
+      null
+    }
+  }
+
+
   lazy val customDbpediaResourceStore: CustomDbpediaResourceStore = try {
     usedStores.add(Store.ResourceStore)
-    new CustomDbpediaResourceStore(pathToFolder)
+    new CustomDbpediaResourceStore(pathToFolder, customQuantizedCountStore)
   } catch {
     case ex: FileNotFoundException => {
       println(ex.getMessage)
@@ -62,7 +78,7 @@ class CustomSpotlightModel(val pathToFolder: String) {
 
   lazy val customCandidateMapStore: CustomCandidateMapStore = try {
     usedStores.add(Store.CandidateStore)
-    new CustomCandidateMapStore(pathToFolder, customDbpediaResourceStore.resStore)
+    new CustomCandidateMapStore(pathToFolder, customDbpediaResourceStore.resStore, customQuantizedCountStore)
   } catch {
     case ex: Exception => {
       println(ex.getMessage)
@@ -72,7 +88,7 @@ class CustomSpotlightModel(val pathToFolder: String) {
 
   lazy val customSurfaceFormStore: CustomSurfaceFormStore = try {
     usedStores.add(Store.SurfaceStore)
-    new CustomSurfaceFormStore(pathToFolder)
+    new CustomSurfaceFormStore(pathToFolder, customQuantizedCountStore)
   } catch {
     case ex: FileNotFoundException => {
       println(ex.getMessage)
@@ -93,7 +109,7 @@ class CustomSpotlightModel(val pathToFolder: String) {
   lazy val customContextStore: CustomContextStore =
   try {
     usedStores.add(Store.ContextStore)
-    new CustomContextStore(pathToFolder, customTokenTypeStore.tokenStore)
+    new CustomContextStore(pathToFolder, customTokenTypeStore.tokenStore, customQuantizedCountStore)
   } catch {
     case ex: FileNotFoundException => {
       println(ex.getMessage)
@@ -106,6 +122,15 @@ class CustomSpotlightModel(val pathToFolder: String) {
   * */
   def exportModels(pathToFolder: String) {
     println("exporting models to.." + pathToFolder)
+
+    try{
+      if(usedStores.contains(Store.QuantiziedStore))
+         MemoryStore.dump(this.customQuantizedCountStore.quantizedStore, new File(pathToFolder,"quantized_counts.mem"))
+    }catch{
+      case ex: Exception =>{
+        println(ex.getMessage)
+      }
+    }
 
     try {
       if(usedStores.contains(Store.ResourceStore))
@@ -135,8 +160,13 @@ class CustomSpotlightModel(val pathToFolder: String) {
     }
 
     try {
-      if(usedStores.contains(Store.TokenStore))
+      if(usedStores.contains(Store.TokenStore) ||
+         usedStores.contains(Store.SurfaceStore) ||
+         usedStores.contains(Store.ContextStore) ){
+         this.customSurfaceFormStore.sfStore.quantizedCountStore = this.customQuantizedCountStore.quantizedStore
+         this.customTokenTypeStore.addAllTokensInSurfaceFormStore(this.customSurfaceFormStore.sfStore)
          MemoryStore.dump(this.customTokenTypeStore.tokenStore, new File(pathToFolder, "tokens.mem"))
+      }
     } catch {
       case ex: Exception => {
         println(ex.getMessage)
@@ -144,16 +174,44 @@ class CustomSpotlightModel(val pathToFolder: String) {
     }
 
     try {
-      if(usedStores.contains(Store.ContextStore))
+      if(usedStores.contains(Store.ContextStore)){
+         this.customContextStore.sortTokensInContextStore()
          MemoryStore.dump(this.customContextStore.contextStore, new File(pathToFolder, "context.mem"))
+      }
     } catch {
       case ex: Exception => {
         println(ex.getMessage)
       }
     }
 
+    try{
+      if(usedStores.contains(Store.TokenStore) ||
+        usedStores.contains(Store.SurfaceStore) ||
+        usedStores.contains(Store.ContextStore) ){
+            println("Creating FSA....")
+            val locale = new Locale("en", "US")
+            val stemmer: Stemmer = new SnowballStemmer("EnglishStemmer")
+            val tokenizer: TextTokenizer = new LanguageIndependentTokenizer(Set[String](), stemmer, locale, this.customTokenTypeStore.tokenStore)
+            this.customSurfaceFormStore.sfStore.quantizedCountStore = this.customQuantizedCountStore.quantizedStore
+            val fsaDict = FSASpotter.buildDictionary(this.customSurfaceFormStore.sfStore, tokenizer)
+            MemoryStore.dump(fsaDict, new File(propertyFolder, "fsa_dict.mem"))
+      }
+    }catch{
+      case ex: Exception =>{
+        println(ex.getMessage)
+      }
+    }
+
     println("finished exporting models to.." + pathToFolder)
 
+  }
+
+  def getQuantiziedCounts(count:Int):Short ={
+    return this.customQuantizedCountStore.quantizedStore.addCount(count)
+  }
+
+  def getCountFromQuantiziedValue(quantiziedValue:Short):Int ={
+    return this.customQuantizedCountStore.quantizedStore.getCount(quantiziedValue)
   }
 
   /*
@@ -167,7 +225,7 @@ class CustomSpotlightModel(val pathToFolder: String) {
     val surfaceFormID: Int = this.customSurfaceFormStore.getAddSurfaceForm(surfaceFormText)
     this.customSurfaceFormStore.boostCountsIfNeeded(surfaceFormID)
     // These default values are related to the default values for support filters for the annotation endpoint
-    var defaultSupportForDbpediaResource: Int = 11
+    var defaultSupportForDbpediaResource: Int = 30
     val defaultSupportForCandidate: Int = 30
 
     var avgSupportCandidate = defaultSupportForCandidate
@@ -287,7 +345,14 @@ class CustomSpotlightModel(val pathToFolder: String) {
   def prettyPrintContext(dbpediaResourceURI: String) {
     val dbpediaResourceID: Int = this.customDbpediaResourceStore.resStore.getResourceByName(dbpediaResourceURI).id
     var tokens: Array[Int] = this.customContextStore.contextStore.tokens(dbpediaResourceID)
-    var counts: Array[Int] = this.customContextStore.contextStore.counts(dbpediaResourceID)
+    var quantiziedCounts:Array[Short] = this.customContextStore.contextStore.counts(dbpediaResourceID)
+
+    val counts:Array[Int] = new Array[Int](quantiziedCounts.size)
+    // transforming from quantizied values to real counts
+    for(i<- 0 until quantiziedCounts.size){
+      counts(i) = getCountFromQuantiziedValue(quantiziedCounts(i))
+    }
+
     println("Contexts for " + dbpediaResourceURI + " Id:" + dbpediaResourceID)
     for (i <- 0 to tokens.size - 1) {
       println("\t" + this.customTokenTypeStore.tokenStore.getTokenTypeByID(tokens(i)) + "--" + counts(i))
@@ -461,6 +526,18 @@ class CustomSpotlightModel(val pathToFolder: String) {
       }
     }
     writer.close()
+  }
+
+  /*
+   * Given a map having lowerCaseSF as keys and list of UppercaseSF as values
+   * it will update the internal lowerSurfaceForm maps.
+   * */
+  def addMapOfLowerCaseSurfaceForms(mapOfLowerCaseSfs:collection.mutable.HashMap[String, Array[String]]){
+    this.customSurfaceFormStore.addMapOfLowerCaseSurfaceForms(mapOfLowerCaseSfs)
+  }
+
+  def getLowerCasesSFInStore(setOfLowerCasesSF:Set[String])={
+    this.customSurfaceFormStore.findSetOfSurfaceFormsInMainStore(setOfLowerCasesSF)
   }
 
 }

--- a/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
@@ -201,6 +201,23 @@ object Main {
         modelExplorer.checkEntitiesInFile()
       }
 
+      // looking if a sf is spottable by the fsa
+      case("fsa", "find") => {
+        val surfaceForms = commandLineConfig.argument.split('|')
+        surfaceForms.foreach{ surfaceForm:String =>
+               val spots:Array[String] = spotlightModelReader.getFSASpots(surfaceForm)
+               println("------------------------")
+               println(surfaceForm)
+               println("\tspots:")
+               spots.foreach{
+                   spot: String =>
+                     println("\t\t" + spot)
+               }
+               println("--------------------------")
+        }
+
+      }
+
     }
 
   }

--- a/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
@@ -204,8 +204,8 @@ object Main {
       // looking if a sf is spottable by the fsa
       case("fsa", "find") => {
         val surfaceForms = commandLineConfig.argument.split('|')
-        surfaceForms.foreach{ surfaceForm:String =>
-               val spots:Array[String] = spotlightModelReader.getFSASpots(surfaceForm)
+        surfaceForms.foreach{ surfaceForm: String =>
+               val spots: Array[String] = spotlightModelReader.getFSASpots(surfaceForm)
                println("------------------------")
                println(surfaceForm)
                println("\tspots:")

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
@@ -210,4 +210,5 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     this.candidateMap.candidateCounts(destinationSurfaceForm.id) = newDestinationCandidatesCounts
 
   }
+}
 

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
@@ -29,16 +29,18 @@ import org.idio.dbpedia.spotlight.utils.ArrayUtils
 
 class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
                               val pathtoFolder: String,
-                              val resStore:
-                              MemoryResourceStore) {
+                              val resStore:MemoryResourceStore,
+                              val countStore: CustomQuantiziedCountStore) extends QuantiziedMemoryStore {
 
-  def this(pathtoFolder: String, resStore: MemoryResourceStore) {
-    this(MemoryStore.loadCandidateMapStore(new FileInputStream(new File(pathtoFolder, "candmap.mem")), resStore),
-                                           pathtoFolder, resStore)
+  quantizedCountStore = countStore
+
+  def this(pathtoFolder: String, resStore: MemoryResourceStore, countStore: CustomQuantiziedCountStore) {
+    this(MemoryStore.loadCandidateMapStore(new FileInputStream(new File(pathtoFolder, "candmap.mem")), resStore, countStore.quantizedStore),
+                                           pathtoFolder, resStore, countStore)
   }
 
-  def this(candidateMap: MemoryCandidateMapStore, resStore: MemoryResourceStore) {
-    this(candidateMap, "", resStore)
+  def this(candidateMap: MemoryCandidateMapStore, resStore: MemoryResourceStore, countStore: CustomQuantiziedCountStore) {
+    this(candidateMap, "", resStore, countStore)
   }
 
   /*
@@ -49,6 +51,9 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
   * if it is not it will add it
   * */
   def addOrCreate(surfaceFormID: Int, candidateID: Int, candidateCounts: Int) {
+
+    val quantiziedCandidateCounts:Short = getQuantiziedCounts(candidateCounts)
+
     // try to get it, create the candidate array in case it doesnt exist
     try {
       this.candidateMap.candidates(surfaceFormID)
@@ -56,8 +61,8 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
       case e: Exception => {
         println("\tcreating candidate map array for " + surfaceFormID)
 
-        val candidates: Array[Int] = Array(candidateID)
-        val counts: Array[Int] = Array(candidateCounts)
+        val candidates: Array[Int] = Array[Int](candidateID)
+        val counts: Array[Int] = Array[Int](candidateCounts)
         this.createCandidateMapForSurfaceForm(surfaceFormID, candidates, counts)
 
         println("\tcandidates")
@@ -80,7 +85,7 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
         println("\tcreating candidate map array for " + surfaceFormID)
 
         this.candidateMap.candidates(surfaceFormID) = Array[Int](candidateID)
-        this.candidateMap.candidateCounts(surfaceFormID) = Array[Int](candidateCounts)
+        this.candidateMap.candidateCounts(surfaceFormID) = Array[Short](quantiziedCandidateCounts)
 
         println("\tcandidates")
 
@@ -107,7 +112,16 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
   * */
   def createCandidateMapForSurfaceForm(surfaceFormID: Int, listOfCandidates: Array[Int], listOfCounts: Array[Int]) {
     this.candidateMap.candidates = Array concat (this.candidateMap.candidates, Array(listOfCandidates))
-    this.candidateMap.candidateCounts = Array concat (this.candidateMap.candidateCounts, Array(listOfCounts))
+
+    // transofrming the counts into quantized equivalents
+    val listOfQuantizedCounts:Array[Short] = new Array[Short](listOfCounts.size)
+
+    for(i <- 0 until listOfCounts.size){
+      val currentCount = listOfCounts(i)
+      listOfQuantizedCounts(i) = getQuantiziedCounts(currentCount)
+    }
+
+    this.candidateMap.candidateCounts = Array concat (this.candidateMap.candidateCounts, Array(listOfQuantizedCounts))
   }
 
   /*
@@ -116,8 +130,8 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
 * */
   def getAVGSupportForSF(surfaceFormID: Int): Int = {
     val candidateCounts = this.candidateMap.candidateCounts(surfaceFormID)
-    if (candidateCounts.isInstanceOf[Array[Int]]) {
-      return (candidateCounts.sum / candidateCounts.size.toDouble).toInt
+    if (candidateCounts.isInstanceOf[Array[Short]]) {
+      return (candidateCounts.map(x => this.getCountFromQuantiziedValue(x)).sum  / candidateCounts.size.toDouble).toInt
     }
     return 0
   }
@@ -140,7 +154,8 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     // update the candidate count value
     println("updating candidate count value")
     val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexWhere { case (x) => x == candidateID }
-    this.candidateMap.candidateCounts(surfaceFormID)(indexOfCandidateInArray) += boostValue
+    val newQuantizedCount:Short = getQuantiziedCounts(boostValue)
+    this.candidateMap.candidateCounts(surfaceFormID)(indexOfCandidateInArray) = newQuantizedCount
   }
 
   /*
@@ -149,7 +164,8 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
   def addNewCandidateToSF(surfaceFormID: Int, candidateID: Int, candidateCounts: Int) {
     if (!this.checkCandidateInSFCandidates(surfaceFormID, candidateID)) {
       this.candidateMap.candidates(surfaceFormID) = this.candidateMap.candidates(surfaceFormID) :+ candidateID
-      this.candidateMap.candidateCounts(surfaceFormID) = this.candidateMap.candidateCounts(surfaceFormID) :+ candidateCounts
+      val quantizedCount: Short = getQuantiziedCounts(candidateCounts)
+      this.candidateMap.candidateCounts(surfaceFormID) = this.candidateMap.candidateCounts(surfaceFormID) :+ quantizedCount
       return 1
     }
     return 0
@@ -195,6 +211,3 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
 
   }
 
-
-
-}

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomFSAStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomFSAStore.scala
@@ -1,0 +1,79 @@
+package org.idio.dbpedia.spotlight.stores
+
+/**
+ * Copyright 2014 Idio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author David Przybilla david.przybilla@idioplatform.com
+ **/
+
+import org.dbpedia.spotlight.db.memory.{ MemoryStore, MemoryResourceStore }
+import java.io.{File, FileInputStream}
+import org.dbpedia.spotlight.db.FSASpotter
+import opennlp.tools.util.Span
+import org.dbpedia.spotlight.model.{Text, Token}
+import org.idio.dbpedia.spotlight.utils.CustomTokenizer
+
+class CustomFSAStore(val modelFolder: String, val customTokenStore: CustomTokenResourceStore, val customTokenizer: CustomTokenizer) {
+
+
+  val fsaDictionary = MemoryStore.loadFSADictionary(new FileInputStream(new File(modelFolder, "fsa_dict.mem")))
+
+
+  private def transverse(sentence:Seq[Token]):  Array[Span] ={
+
+    var spans = Array[Span]()
+    val ids = sentence.map(_.tokenType.id)
+
+    sentence.zipWithIndex.foreach {
+      case(t: Token, i: Int) =>{
+        var currentState = FSASpotter.INITIAL_STATE
+        var j = i
+
+        do {
+          //Get the transition for the next token:
+          val (endState, nextState) = fsaDictionary.next(currentState, ids(j))
+
+          //Add a span if this is a possible spot:
+          if (endState == FSASpotter.ACCEPTING_STATE)
+            spans :+= new Span(i, j+1, "m")
+
+          //Keep traversing the FSA until a rejecting state or the end of the sentence:
+          currentState = nextState
+          j += 1
+        } while ( currentState != FSASpotter.REJECTING_STATE && j < sentence.length )
+      }
+
+    }
+
+    spans
+
+  }
+
+
+  def getFSASpots(surfaceText: String): Array[String] = {
+    val text = new Text(surfaceText)
+    val tokens: Seq[Token] = customTokenizer.tokenizer.tokenize(text)
+    val spans: Array[Span] = transverse(tokens)
+
+    spans.map{
+       span:Span =>
+         List.range(span.getStart, span.getEnd).map(tokens).map(_.token).mkString(" ")
+    }
+
+  }
+
+}

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomFSAStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomFSAStore.scala
@@ -27,13 +27,16 @@ import opennlp.tools.util.Span
 import org.dbpedia.spotlight.model.{Text, Token}
 import org.idio.dbpedia.spotlight.utils.CustomTokenizer
 
-class CustomFSAStore(val modelFolder: String, val customTokenStore: CustomTokenResourceStore, val customTokenizer: CustomTokenizer) {
+class CustomFSAStore(val modelFolder: String,
+                     val customTokenStore: CustomTokenResourceStore,
+                     val customTokenizer: CustomTokenizer) {
 
 
-  val fsaDictionary = MemoryStore.loadFSADictionary(new FileInputStream(new File(modelFolder, "fsa_dict.mem")))
+  val fsaDictionary = MemoryStore.loadFSADictionary(new FileInputStream(new File(new File(modelFolder).getParent,
+                                                    "fsa_dict.mem")))
 
 
-  private def transverse(sentence:Seq[Token]):  Array[Span] ={
+  private def transverse(sentence:Seq[Token]): Array[Span] ={
 
     var spans = Array[Span]()
     val ids = sentence.map(_.tokenType.id)

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomQuantiziedCountStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomQuantiziedCountStore.scala
@@ -1,0 +1,46 @@
+package org.idio.dbpedia.spotlight.stores
+
+import java.io.{File, FileInputStream}
+
+/**
+ * Copyright 2014 Idio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.dbpedia.spotlight.db.memory.{MemoryStore, MemoryQuantizedCountStore}
+import java.io.{File, FileInputStream}
+import org.dbpedia.spotlight.db.stem.SnowballStemmer
+import scala.collection.mutable.HashMap
+
+/**
+ * @author David Przybilla david.przybilla@idioplatform.com
+ **/
+class CustomQuantiziedCountStore(val quantizedStore: MemoryQuantizedCountStore, val pathtoFolder:String) {
+
+  def this(pathToFolder:String){
+     this( MemoryStore.loadQuantizedCountStore(new FileInputStream(new File(pathToFolder, "quantized_counts.mem"))), pathToFolder)
+  }
+
+
+
+  /*
+  * Takes an int value and tries to add it to the Quantizied Store
+  * in case it exists it returns its quantizied version
+  * otherwise it will add it and return its quantizied version
+  * */
+  def addCount(count: Int): Short={
+    return quantizedStore.addCount(count)
+  }
+
+}

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomSurfaceFormStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomSurfaceFormStore.scala
@@ -33,6 +33,20 @@ class CustomSurfaceFormStore(val pathtoFolder: String, val countStore: CustomQua
   var sfStore: MemorySurfaceFormStore = MemoryStore.loadSurfaceFormStore(sfMemFile, quantizedCountStore.quantizedStore)
 
   /*
+  *  Given a lowercase surface form it returns the list of string candidate surface forms
+  *  returns the counts of a sf, and the list of candidates surface forms
+  * */
+  def findInLowerCaseSurfaceForm(surfaceText: String): (Option[Int], Option[Array[String]]) = {
+    if (sfStore.lowercaseMap.containsKey(surfaceText)){
+        val candidates = sfStore.lowercaseMap.get(surfaceText)
+        val counts = candidates(0)
+       (Some(counts), Some(candidates.slice(1,candidates.size).map(sfStore.stringForID)))
+    }else{
+      (None, None)
+   }
+  }
+
+  /*
   * Updates the internal arrays for a new SurfaceForm
   * */
   private def addSF(surfaceText: String) {

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/QuantiziedMemoryStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/QuantiziedMemoryStore.scala
@@ -1,0 +1,43 @@
+package org.idio.dbpedia.spotlight.stores
+
+import org.idio.dbpedia.spotlight.stores.CustomQuantiziedCountStore
+
+/**
+ * Copyright 2014 Idio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author David Przybilla david.przybilla@idioplatform.com
+ **/
+class QuantiziedMemoryStore {
+
+  var quantizedCountStore: CustomQuantiziedCountStore = null
+
+  /*
+  * Returns the quantizied value of a count.
+  * If the count is already in the store it will return it
+  * otherwise it will be created in the quantiziedStore
+  * */
+  def getQuantiziedCounts(count:Int):Short ={
+    return this.quantizedCountStore.quantizedStore.addCount(count)
+  }
+
+  /*
+  *  given a Quantizied value it returns the original count value
+  * */
+  def getCountFromQuantiziedValue(quantiziedValue:Short):Int ={
+    return quantizedCountStore.quantizedStore.getCount(quantiziedValue)
+  }
+}

--- a/src/main/scala/org/idio/dbpedia/spotlight/utils/CommandLineParser.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/utils/CommandLineParser.scala
@@ -144,6 +144,13 @@ class CommandLineParser {
                                               "shows some surface forms and their statistics",
                                               "number of surface forms to explore")
 
+    val fsaCommand = getSimpleCommand("fsa", "querying the finate state automata")
+    fsaCommand.children(
+      getCommandSingleArg("find",
+        "piped separated list of surfaceforms",
+        "checks if each of the given surfaceform ends in a final valid state in the FSA")
+    )
+
   }
 
   def parse(args:  Array[String]): Option[CommandLineConfig] ={

--- a/src/main/scala/org/idio/dbpedia/spotlight/utils/CustomTokenizer.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/utils/CustomTokenizer.scala
@@ -1,0 +1,34 @@
+package org.idio.dbpedia.spotlight.utils
+
+import java.util.Locale
+import org.dbpedia.spotlight.db.model.{TextTokenizer, Stemmer}
+import org.dbpedia.spotlight.db.stem.SnowballStemmer
+import org.dbpedia.spotlight.db.tokenize.LanguageIndependentTokenizer
+import org.idio.dbpedia.spotlight.stores.{CustomTokenResourceStore}
+
+/**
+ * Copyright 2014 Idio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author David Przybilla david.przybilla@idioplatform.com
+ **/
+class CustomTokenizer(val customTokenStore: CustomTokenResourceStore) {
+  val locale = new Locale("en", "US")
+  val stemmer: Stemmer = new SnowballStemmer("EnglishStemmer")
+  val tokenizer: TextTokenizer = new LanguageIndependentTokenizer(Set[String](), stemmer, locale, customTokenStore.tokenStore)
+
+
+}

--- a/src/test/scala/CandidateStoreTest.scala
+++ b/src/test/scala/CandidateStoreTest.scala
@@ -18,9 +18,9 @@
  * @author David Przybilla david.przybilla@idioplatform.com
  **/
 
-import org.dbpedia.spotlight.db.memory.{MemoryResourceStore, MemoryCandidateMapStore}
+import org.dbpedia.spotlight.db.memory.{MemoryQuantizedCountStore, MemoryResourceStore, MemoryCandidateMapStore}
 import org.dbpedia.spotlight.model.SurfaceForm
-import org.idio.dbpedia.spotlight.stores.CustomCandidateMapStore
+import org.idio.dbpedia.spotlight.stores.{CustomQuantiziedCountStore, CustomCandidateMapStore}
 import org.scalatest.mock.MockitoSugar.mock
 import org.junit.Test
 import org.junit.Assert._
@@ -33,21 +33,33 @@ class CandidateStoreTest {
     // mock needed objects
     val candidateMap:MemoryCandidateMapStore = new MemoryCandidateMapStore()
     val resStore:MemoryResourceStore = mock[MemoryResourceStore]
+    val quantiziedStore:CustomQuantiziedCountStore = mock[CustomQuantiziedCountStore]
+
+
+    val candidateCounts1 = Array[Int](50, 1, 100)
+    val candidateCounts2 = Array[Int](14, 55)
+    // adding candidate counts to quantizied Store
+    val quantizedCounts1 = candidateCounts1.map(quantiziedStore.addCount)
+    val quantizedCounts2 = candidateCounts2.map(quantiziedStore.addCount)
 
     //mock candidate store
     candidateMap.candidates = Array[Array[Int]]( Array[Int](1, 2, 3), Array[Int](3, 5) )
-    candidateMap.candidateCounts= Array[Array[Int]]( Array[Int](50, 1, 100),  Array[Int](14, 55))
+    candidateMap.candidateCounts= Array[Array[Short]]( quantizedCounts1,  quantizedCounts2)
+
 
     val sourceSurfaceForm =  new SurfaceForm("sf1", 0, 100, 200)
     val destinySurfaceForm = new  SurfaceForm("sf2", 1, 50, 200)
 
 
-    var customCandidateMapStore:CustomCandidateMapStore = new CustomCandidateMapStore(candidateMap, "", resStore)
+    var customCandidateMapStore:CustomCandidateMapStore = new CustomCandidateMapStore(candidateMap, "", resStore, quantiziedStore)
 
     // test copy candidates
     customCandidateMapStore.copyCandidates(sourceSurfaceForm, destinySurfaceForm)
 
-    val expectedCandidateCounts = collection.immutable.Map[Int, Int](1->50, 2->1, 3->100, 5->55)
+    val expectedCandidateCounts = collection.immutable.Map[Int, Short](1->quantiziedStore.addCount(50),
+                                                                     2->quantiziedStore.addCount(1),
+                                                                     3->quantiziedStore.addCount(100),
+                                                                     5->quantiziedStore.addCount(55))
 
     //check the candidate topics set
     val candidateTopicsForDestinySurfaceForm = customCandidateMapStore.candidateMap.candidates(1)

--- a/tools/explore.scala
+++ b/tools/explore.scala
@@ -41,7 +41,7 @@ lazy val quantizedStore:MemoryQuantizedCountStore= MemoryStore.loadQuantizedCoun
                                                          new FileInputStream(new File(pathtoFolder, "quantized_counts.mem")))
 
 lazy val resStore:MemoryResourceStore = MemoryStore.loadResourceStore(
-                                                      new FileInputStream(new File(pathtoFolder, "res.mem")))
+                                                      new FileInputStream(new File(pathtoFolder, "res.mem")), quantizedStore)
 
 lazy val sfStore:MemorySurfaceFormStore = MemoryStore.loadSurfaceFormStore(
                                                       new FileInputStream(new File(pathtoFolder, "sf.mem")), quantizedStore)

--- a/tools/explore.scala
+++ b/tools/explore.scala
@@ -27,29 +27,33 @@
 * once in the scala console type: :load pathToScript/explore.scala
 *
 * */
-:cp /usr/share/java/dbpedia-spotlight-0.6.jar
+:cp /usr/share/java/dbpedia-spotlight-0.7.jar
 import java.io.{File, FileInputStream}
 import org.dbpedia.spotlight.db.memory.{MemoryStore, MemoryContextStore, MemorySurfaceFormStore,
-                                        MemoryResourceStore, MemoryCandidateMapStore, MemoryTokenTypeStore}
+                                        MemoryResourceStore, MemoryCandidateMapStore, MemoryTokenTypeStore,
+                                        MemoryQuantizedCountStore}
 import org.dbpedia.spotlight.model.{Candidate, SurfaceForm, DBpediaResource}
  
 val pathtoFolder= "/mnt/share/spotlight/en/model"
 
 //Loading all the stores
+lazy val quantizedStore:MemoryQuantizedCountStore= MemoryStore.loadQuantizedCountStore(
+                                                         new FileInputStream(new File(pathtoFolder, "quantized_counts.mem")))
+
 lazy val resStore:MemoryResourceStore = MemoryStore.loadResourceStore(
-                                                      new FileInputStream(new File(pathtoFolder,"res.mem")))
+                                                      new FileInputStream(new File(pathtoFolder, "res.mem")))
 
 lazy val sfStore:MemorySurfaceFormStore = MemoryStore.loadSurfaceFormStore(
-                                                      new FileInputStream(new File(pathtoFolder,"sf.mem")))
+                                                      new FileInputStream(new File(pathtoFolder, "sf.mem")), quantizedStore)
 
 lazy val candidateMap:MemoryCandidateMapStore = MemoryStore.loadCandidateMapStore(
-                                                    new FileInputStream(new File(pathtoFolder,"candmap.mem")),
-                                                    resStore)
+                                                    new FileInputStream(new File(pathtoFolder, "candmap.mem")),
+                                                    resStore, quantizedStore)
 
 // make sure you give enough heap if you are ever using any of these two following stores:
 lazy val tokenStore:MemoryTokenTypeStore = MemoryStore.loadTokenTypeStore(
-                                                    new FileInputStream(new File(pathtoFolder,"tokens.mem")))
+                                                    new FileInputStream(new File(pathtoFolder, "tokens.mem")))
 
 lazy val contextStore:MemoryContextStore = MemoryStore.loadContextStore(
-                                                    new FileInputStream(new File(pathtoFolder,"context.mem")),
-                                                    tokenStore)
+                                                    new FileInputStream(new File(pathtoFolder, "context.mem")),
+                                                    tokenStore, quantizedStore)


### PR DESCRIPTION
This branch contains all the clean up plus all changes needed to edit spotlight 0.7 models. it is not meant to be merged until we have a stable 0.7 model
- Introduced a new command `fsa find` for checking  the spots returned by the finate state automata(fsa) given a surface form. This is somethign we will be needing when debugging to either: 
  - Check whether a lowercase sf is spottable via the fsa
  - Check if a surface form is spottable but one of its sub-surface forms is selected i.e: `Nintendo Wii` has two possible matches via the fsa : `Nintendo` and `Nintendo Wii`
- Getting stats for surface forms now checks the uppercaseSFStore if nothing is found there it goes to the lowercaseSFStore. 
- When getting stats of SFs located in the lowercaseSfStore, its candidates SF(Sf in the  upperCaseSFStore) are printed

Note: 
- I generated a new model using this editor + [the discount sf fix](https://github.com/dbpedia-spotlight/dbpedia-spotlight/pull/298). There is an experimental spotlight's model living in the bucket: `experimental-spotlight-models`. 

---
- [x] remember thiago
- [ ] add a task list
