### PR TITLE
Feature/adding types

### DIFF
--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
@@ -38,16 +38,16 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
   * */
   private def addDbpediaURI(uri: String, support: Int, types: Array[String]) {
     //URI i.e: Click-through_rate
-    //Types: ToDo: Currently we don't handle the types as they should be
+    //Types: TODO: Currently we don't handle the types as they should be
 
     val quantizedCounts:Short= getQuantiziedCounts(support)
-
+    // Adds support for new Id
     this.resStore.supportForID = Array concat (resStore.supportForID, Array(quantizedCounts))
+    // Adds uri for new Id
     this.resStore.uriForID = Array concat (resStore.uriForID, Array(uri))
+    // Adds types for new ID
+    setOntologyTypes(this.resStore.getResourceByName(uri).id, types)
 
-    var dbpediaTypesForResource: Array[Array[java.lang.Short]] = this.getTypesIds(types)
-
-    this.resStore.typesForID = Array concat (resStore.typesForID, dbpediaTypesForResource)
   }
 
   def setSupport(resourceId:Int, support:Int){
@@ -63,6 +63,7 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
     try {
       val resourceID = this.resStore.getResourceByName(uri).id
       println("\tfound dbpedia resource for:" + uri + "--" + resourceID)
+      setOntologyTypes(resourceID, types)
       return resourceID
     } catch {
 
@@ -100,8 +101,8 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
   * Given a list of string of types it return a list wth types ids:
   * i.e: [dbpdia:person, dbpedia:location] => [100, 392]..
   * */
-  def getTypesIds(dbpediaTypes: Array[String]): Array[Array[java.lang.Short]] = {
-    var dbpediaTypesForResource2 = new Array[Array[java.lang.Short]](1)
+  def getTypesIds(dbpediaTypes: Array[String]): Array[java.lang.Short] = {
+    //var dbpediaTypesForResource2 = new Array[Array[java.lang.Short]](1)
     var dbpediaTypesForResource: Array[java.lang.Short] = new Array[java.lang.Short](dbpediaTypes.length)
 
     for (i <- 0 to dbpediaTypes.length - 1) {
@@ -115,8 +116,13 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
       }
     }
 
-    dbpediaTypesForResource2(0) = dbpediaTypesForResource.filter(_ != null)
-    return dbpediaTypesForResource2
+    //dbpediaTypesForResource2(0) = dbpediaTypesForResource.filter(_ != null)
+    return dbpediaTypesForResource.filter(_ != null)
   }
+
+  def setOntologyTypes(resourceID:Int, ontologyTypes:Array[String]) {
+    this.resStore.typesForID(resourceID)  = (this.resStore.typesForID(resourceID) ++ this.getTypesIds(ontologyTypes)).distinct
+  }
+
 
 }

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
@@ -24,6 +24,7 @@ package org.idio.dbpedia.spotlight.stores
 import org.dbpedia.spotlight.db.memory.{ MemoryStore, MemoryResourceStore }
 import java.io.{FileInputStream, File}
 import org.dbpedia.spotlight.exceptions.DBpediaResourceNotFoundException
+import collection.JavaConversions._
 import org.idio.dbpedia.spotlight.stores.CustomQuantiziedCountStore
 
 class CustomDbpediaResourceStore(val pathtoFolder: String,
@@ -106,22 +107,12 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
   * i.e: [dbpdia:person, dbpedia:location] => [100, 392]..
   * */
   def getTypesIds(dbpediaTypes: Array[String]): Array[java.lang.Short] = {
-    //var dbpediaTypesForResource2 = new Array[Array[java.lang.Short]](1)
-    var dbpediaTypesForResource: Array[java.lang.Short] = new Array[java.lang.Short](dbpediaTypes.length)
-
-    for (i <- 0 to dbpediaTypes.length - 1) {
-      var currentType: String = dbpediaTypes(i)
-      if (!currentType.equals("")) {
-
-        try dbpediaTypesForResource(i) = resStore.ontologyTypeStore.getOntologyTypeByName(currentType).id
-        catch {
-          case ex: NullPointerException => {println("Could not find a type in Ontology Store for: " + currentType)}
-        }
+    dbpediaTypes.map( ty => {
+      try Some(resStore.ontologyTypeStore.getOntologyTypeByName(ty).id)
+      catch {
+        case _ => None
       }
-    }
-
-    //dbpediaTypesForResource2(0) = dbpediaTypesForResource.filter(_ != null)
-    return dbpediaTypesForResource.filter(_ != null)
+    }).flatten
   }
 
   def setOntologyTypes(resourceID:Int, ontologyTypes:Array[String]) {

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
@@ -36,7 +36,7 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
   /*
   * Creates the specified DbpediaResource in the internal Arrays
   * */
-  private def addDbpediaURI(uri: String, support: Int, types: Array[String]) {
+  private def addDbpediaURI(uri: String, support: Int) {
     //URI i.e: Click-through_rate
     //Types: TODO: Currently we don't handle the types as they should be
 
@@ -45,8 +45,9 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
     this.resStore.supportForID = Array concat (resStore.supportForID, Array(quantizedCounts))
     // Adds uri for new Id
     this.resStore.uriForID = Array concat (resStore.uriForID, Array(uri))
-    // Adds types for new ID
-    setOntologyTypes(this.resStore.getResourceByName(uri).id, types)
+
+    // Adds an empty type array for the new ID
+    this.resStore.typesForID = Array concat (this.resStore.typesForID,  Array(Array[java.lang.Short]()))
 
   }
 
@@ -81,10 +82,13 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
   def addDbpediaResource(uri: String, support: Int, types: Array[String]): Int = {
 
     // add the dbpedia URI to the arrays
-    this.addDbpediaURI(uri, support, types)
+    this.addDbpediaURI(uri, support)
 
     //update internal indexes
     this.resStore.createReverseLookup()
+
+    // Adds types for new ID
+    setOntologyTypes(this.resStore.getResourceByName(uri).id, types)
 
     return this.resStore.getResourceByName(uri).id
   }

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
@@ -107,11 +107,15 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
     for (i <- 0 to dbpediaTypes.length - 1) {
       var currentType: String = dbpediaTypes(i)
       if (!currentType.equals("")) {
-        dbpediaTypesForResource(i) = resStore.ontologyTypeStore.getOntologyTypeByName(currentType).id
+
+        try dbpediaTypesForResource(i) = resStore.ontologyTypeStore.getOntologyTypeByName(currentType).id
+        catch {
+          case ex: NullPointerException => {println("Could not find a type in Ontology Store for: " + currentType)}
+        }
       }
     }
 
-    dbpediaTypesForResource2(0) = dbpediaTypesForResource
+    dbpediaTypesForResource2(0) = dbpediaTypesForResource.filter(_ != null)
     return dbpediaTypesForResource2
   }
 

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomDbpediaResourceStore.scala
@@ -116,8 +116,10 @@ class CustomDbpediaResourceStore(val pathtoFolder: String,
   }
 
   def setOntologyTypes(resourceID:Int, ontologyTypes:Array[String]) {
-    this.resStore.typesForID(resourceID)  = (this.resStore.typesForID(resourceID) ++ this.getTypesIds(ontologyTypes)).distinct
-  }
+    if (!ontologyTypes.isEmpty)){
+      this.resStore.typesForID(resourceID)  = (this.resStore.typesForID(resourceID) ++ this.getTypesIds(ontologyTypes)).distinct
 
+    }
+  }
 
 }

--- a/src/main/scala/org/idio/dbpedia/spotlight/utils/ModelFileParser.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/utils/ModelFileParser.scala
@@ -64,9 +64,10 @@ class ModelFileParser(pathToFile: String) {
     val splittedLine = line.trim.split("\t")
 
     // Get the data from the splitted line
-    val dbpediaURI = splittedLine(0)
+    val resourceInfo = splittedLine(0).split('|')
+    val dbpediaURI = resourceInfo.head
     val surfaceForms = splittedLine(1).split('|')
-    val types = new Array[String](0)
+    val types = resourceInfo.tail
     var contextWordsArray = new Array[String](0)
     var contextCounts = new Array[Int](0)
 


### PR DESCRIPTION
This PR adds the functionality of parsing types from a file when adding resources if the resource comes with a pipe separated list of types `DBPediaResource|type1|type2` and so on.
- [x] honka david
- [x] more David since he now has all the power (double ticks not required for public PRs) - mal
