### PR TITLE
Feature - Handling Association Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ for instructions on how to set up a project.
     - [Making a list of Surface Forms Spottable](#making-a-list-of-surface-forms-spottable)
     - [Set the Context Words of a Topic](#set-the-context-words-of-a-topic)
     - [Deleting Associations between SF and Topics](#deleting-associations-between-sf-and-topics)
+    - [Update Percentage of Context Vector](#percentage-of-context-vector)
 - [Updating Model From File](#updating-model-from-file)
     - [Insight](#insight)
     - [Updating a model From File (All in One Go)](#updating-a-model-from-file-all-in-one-go)
@@ -279,6 +280,29 @@ example:
 ```
 sh target/bin/model-editor association remove /mnt/share/spotlight/en/model /path/to/file/file_with_associations
 ```
+
+### Update Percentage of Context Vector
+
+- **command**: `association`
+- **subcommand**: `percentage-context-vector`
+- **arg1**: `pathToSpotlightModel/model`
+- **arg2**: `pathToInputFile`
+- **result**: All associations between SFs and Topics in the given input file will updated such that support of the association enforces the pass value of percentage-of-context-vector
+
+Every line in the input file describes an association which will be deleted, each line should follow the format:
+
+```
+dbpediaURI <tab> Surface Form <tab> enforcePercentageOfContextVector
+```
+
+
+
+example:
+```
+sh target/bin/model-editor association percentage-context-vector path/to/model path/to/changes.tsv
+```
+
+
 
 ### FSA
 

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -79,7 +79,7 @@ class CustomSpotlightModel(val pathToFolder: String) {
 
   lazy val customCandidateMapStore: CustomCandidateMapStore = try {
     usedStores.add(Store.CandidateStore)
-    new CustomCandidateMapStore(pathToFolder, customDbpediaResourceStore.resStore, customQuantizedCountStore)
+    new CustomCandidateMapStore(pathToFolder, customDbpediaResourceStore.resStore, customSurfaceFormStore.sfStore, customQuantizedCountStore)
   } catch {
     case ex: Exception => {
       println(ex.getMessage)

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -20,6 +20,7 @@
 
 package org.idio.dbpedia.spotlight
 
+import org.dbpedia.spotlight.exceptions.{DBpediaResourceNotFoundException, SurfaceFormNotFoundException}
 import org.dbpedia.spotlight.model.{ Candidate, TokenType, OntologyType }
 import org.dbpedia.spotlight.db.memory.MemoryStore
 import java.io.File
@@ -513,6 +514,12 @@ class CustomSpotlightModel(val pathToFolder: String) {
       this.customCandidateMapStore.removeAssociation(surfaceFormId, dbpediaId)
 
     } catch {
+      case e: SurfaceFormNotFoundException => {
+        println("Surface form not found:" + surfaceFormText)
+      }
+      case e: DBpediaResourceNotFoundException =>{
+        println("DBpediaResource not found:" + dbpediaURI)
+      }  
       case e: Exception => {
         println("\t Given dbpediaURI or SF: " + dbpediaURI + " , " + surfaceFormText + " could not be found")
       }

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -300,6 +300,8 @@ class CustomSpotlightModel(val pathToFolder: String) {
 
     } catch {
       case ex: Exception => {
+        println(ex.getMessage + "\n")
+        ex.printStackTrace()
         println("\tNot Context Store found....")
         println("\tSkipping Context Tokens....")
       }

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -159,7 +159,6 @@ class CustomSpotlightModel(val pathToFolder: String) {
 
     try {
       if(usedStores.contains(Store.CandidateStore))
-         println("exporting candidate store")
           MemoryStore.dump(this.customCandidateMapStore.candidateMap, new File(pathToFolder, "candmap.mem"))
     } catch {
       case ex: Exception => {

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -159,6 +159,7 @@ class CustomSpotlightModel(val pathToFolder: String) {
 
     try {
       if(usedStores.contains(Store.CandidateStore))
+         println("exporting candidate store")
           MemoryStore.dump(this.customCandidateMapStore.candidateMap, new File(pathToFolder, "candmap.mem"))
     } catch {
       case ex: Exception => {

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -544,6 +544,12 @@ class CustomSpotlightModel(val pathToFolder: String) {
       this.customCandidateMapStore.changePercentageOfContextVector(surfaceFormAnnotatedCount, surfaceFormId, dbpediaId, surfaceFormCounts, percentageOfVector)
 
     } catch {
+      case e: SurfaceFormNotFoundException => {
+        println("Surface form not found:" + surfaceForm)
+      }
+      case e: DBpediaResourceNotFoundException =>{
+        println("DBpediaResource not found:" + dbpediaURI)
+      }
       case e: Exception => {
         println("\t Given dbpediaURI or SF: " + dbpediaURI + " , " + surfaceForm + " could not be found")
       }

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -521,6 +521,28 @@ class CustomSpotlightModel(val pathToFolder: String) {
 
   }
 
+
+  /*
+  * Change % of context vector
+  * */
+  def updatePercentageOfContextVector(surfaceForm: String, dbpediaURI: String, percentageOfVector: Double): Unit ={
+
+    try{
+      val surfaceFormId = this.customSurfaceFormStore.sfStore.getSurfaceForm(surfaceForm).id
+      val surfaceFormCounts = this.customSurfaceFormStore.sfStore.getSurfaceForm(surfaceForm).totalCount
+      val dbpediaId = this.customDbpediaResourceStore.resStore.getResourceByName(dbpediaURI).id
+      this.customCandidateMapStore.changePercentageOfContextVector(surfaceFormId, dbpediaId, surfaceFormCounts, percentageOfVector)
+
+    } catch {
+      case e: Exception => {
+        println("\t Given dbpediaURI or SF: " + dbpediaURI + " , " + surfaceForm + " could not be found")
+      }
+    }
+
+
+  }
+
+
   /**
    *  Given an SF return the list of candidate Topics
    */

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -532,7 +532,8 @@ class CustomSpotlightModel(val pathToFolder: String) {
       val surfaceFormId = this.customSurfaceFormStore.sfStore.getSurfaceForm(surfaceForm).id
       val surfaceFormCounts = this.customSurfaceFormStore.sfStore.getSurfaceForm(surfaceForm).totalCount
       val dbpediaId = this.customDbpediaResourceStore.resStore.getResourceByName(dbpediaURI).id
-      this.customCandidateMapStore.changePercentageOfContextVector(surfaceFormId, dbpediaId, surfaceFormCounts, percentageOfVector)
+      val surfaceFormAnnotatedCount = this.customSurfaceFormStore.sfStore.getSurfaceForm(surfaceForm).annotatedCount
+      this.customCandidateMapStore.changePercentageOfContextVector(surfaceFormAnnotatedCount, surfaceFormId, dbpediaId, surfaceFormCounts, percentageOfVector)
 
     } catch {
       case e: Exception => {

--- a/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/CustomSpotlightModel.scala
@@ -519,7 +519,7 @@ class CustomSpotlightModel(val pathToFolder: String) {
       }
       case e: DBpediaResourceNotFoundException =>{
         println("DBpediaResource not found:" + dbpediaURI)
-      }  
+      }
       case e: Exception => {
         println("\t Given dbpediaURI or SF: " + dbpediaURI + " , " + surfaceFormText + " could not be found")
       }

--- a/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
@@ -167,6 +167,22 @@ object Main {
         spotlightModelReader.exportModels(pathToModelFolder)
       }
 
+      case("association", "percentage_context_vector") =>{
+        val pathToFileWithSFTopicPairs = commandLineConfig.argument
+        val sourceFile = scala.io.Source.fromFile(pathToFileWithSFTopicPairs)
+
+        sourceFile.getLines().foreach { line =>
+          val splitLine = line.trim().split("\t")
+          val dbpediaURI = splitLine(0)
+          val surfaceFormText = splitLine(1)
+          val percentageOfContextVector = splitLine(2).toDouble
+          spotlightModelReader.updatePercentageOfContextVector(surfaceFormText, dbpediaURI, percentageOfContextVector)
+          println("Updating association's support : " + dbpediaURI + " -- " + surfaceFormText + " - to allow new percentage of context vector : " + percentageOfContextVector )
+        }
+        println("Exporting new model.....")
+        spotlightModelReader.exportModels(pathToModelFolder)
+      }
+
       // Export context to a file
       case("context", "export") =>{
         println("Exporting contexts.....")

--- a/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/SpotlightModelReader.scala
@@ -167,7 +167,7 @@ object Main {
         spotlightModelReader.exportModels(pathToModelFolder)
       }
 
-      case("association", "percentage_context_vector") =>{
+      case("association", "percentage-context-vector") =>{
         val pathToFileWithSFTopicPairs = commandLineConfig.argument
         val sourceFile = scala.io.Source.fromFile(pathToFileWithSFTopicPairs)
 

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
@@ -175,6 +175,8 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
 
     val newQuantizedCount:Short = getQuantiziedCounts(candidateCount)
 
+    println("\t updating candidate support from: " +  this.candidateMap.candidates(surfaceFormID)(indexOfCandidateInArray) + " to:" + newQuantizedCount)
+
     this.candidateMap.candidateCounts(surfaceFormID)(indexOfCandidateInArray) = newQuantizedCount
   }
 
@@ -186,6 +188,7 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     println("updating candidate count value")
     val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexWhere { case (x) => x == candidateID }
     val newQuantizedCount:Short = getQuantiziedCounts(boostValue)
+    this.candidateMap.candidates
     this.candidateMap.candidateCounts(surfaceFormID)(indexOfCandidateInArray) = newQuantizedCount
   }
 

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
@@ -26,6 +26,7 @@ import java.io.{ File, FileInputStream }
 import Array.concat
 import org.dbpedia.spotlight.model.SurfaceForm
 import org.idio.dbpedia.spotlight.utils.ArrayUtils
+import org.dbpedia.spotlight.db.similarity.PercentageOfContextVector
 
 class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
                               val pathtoFolder: String,
@@ -163,15 +164,9 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
 
   def changePercentageOfContextVector(surfaceFormAnnotatedCount:Int, surfaceFormID: Int, dbpediaId: Int, surfaceFormCounts:Int, percentageOfVector: Double): Unit ={
 
-    def getCandidateSupport( surfaceFormCounts:Int, percentageOfVector: Double): Int = {
-      val numerator = (surfaceFormCounts + 3)
-      val denominator = (1-(2*(percentageOfVector - 0.1)))/(5*(percentageOfVector-0.1))
-      val candidateSupport = (numerator/ math.pow(math.E, denominator)) - 3
-      candidateSupport.toInt
-    }
 
     val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexWhere { case (x) => x == dbpediaId }
-    val candidateCount = getCandidateSupport(surfaceFormCounts, percentageOfVector)
+    val candidateCount = PercentageOfContextVector.candidateSupport(surfaceFormCounts, percentageOfVector)
 
     val maxCandidateCount = (surfaceFormAnnotatedCount * 0.9).toInt
     val newCandidateCount = Math.min(maxCandidateCount, candidateCount)

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
@@ -162,7 +162,8 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     return false
   }
 
-  def changePercentageOfContextVector(surfaceFormAnnotatedCount:Int, surfaceFormID: Int, dbpediaId: Int, surfaceFormCounts:Int, percentageOfVector: Double): Unit ={
+  def changePercentageOfContextVector(surfaceFormAnnotatedCount: Int, surfaceFormID: Int, dbpediaId: Int,
+                                      surfaceFormCounts: Int, percentageOfVector: Double): Unit ={
 
 
     val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexWhere { case (x) => x == dbpediaId }
@@ -171,7 +172,7 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     val maxCandidateCount = (surfaceFormAnnotatedCount * 0.9).toInt
     val newCandidateCount = Math.min(maxCandidateCount, candidateCount)
 
-    val newQuantizedCount:Short = getQuantiziedCounts(newCandidateCount)
+    val newQuantizedCount: Short = getQuantiziedCounts(newCandidateCount)
 
     println("\t updating candidate support from: " +  this.candidateMap.candidates(surfaceFormID)(indexOfCandidateInArray) + " to:" + newQuantizedCount)
 
@@ -186,7 +187,6 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     println("updating candidate count value")
     val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexWhere { case (x) => x == candidateID }
     val newQuantizedCount:Short = getQuantiziedCounts(boostValue)
-    this.candidateMap.candidates
     this.candidateMap.candidateCounts(surfaceFormID)(indexOfCandidateInArray) = newQuantizedCount
   }
 
@@ -207,7 +207,7 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
   * Remove association between an SF and a DbpediaURI
   * */
   def removeAssociation(surfaceFormID: Int, candidateID: Int) {
-    val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexWhere { case (x) => x == candidateID }
+    val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexOf(candidateID)
     this.candidateMap.candidates(surfaceFormID) = ArrayUtils.dropIndex(this.candidateMap.candidates(surfaceFormID), indexOfCandidateInArray)
     this.candidateMap.candidateCounts(surfaceFormID) = ArrayUtils.dropIndex(this.candidateMap.candidateCounts(surfaceFormID), indexOfCandidateInArray)
   }

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
@@ -161,7 +161,7 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     return false
   }
 
-  def changePercentageOfContextVector(surfaceFormID: Int, dbpediaId: Int, surfaceFormCounts:Int, percentageOfVector: Double): Unit ={
+  def changePercentageOfContextVector(surfaceFormAnnotatedCount:Int, surfaceFormID: Int, dbpediaId: Int, surfaceFormCounts:Int, percentageOfVector: Double): Unit ={
 
     def getCandidateSupport( surfaceFormCounts:Int, percentageOfVector: Double): Int = {
       val numerator = (surfaceFormCounts + 3)
@@ -173,7 +173,10 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexWhere { case (x) => x == dbpediaId }
     val candidateCount = getCandidateSupport(surfaceFormCounts, percentageOfVector)
 
-    val newQuantizedCount:Short = getQuantiziedCounts(candidateCount)
+    val maxCandidateCount = (surfaceFormAnnotatedCount * 0.9).toInt
+    val newCandidateCount = Math.min(maxCandidateCount, candidateCount)
+
+    val newQuantizedCount:Short = getQuantiziedCounts(newCandidateCount)
 
     println("\t updating candidate support from: " +  this.candidateMap.candidates(surfaceFormID)(indexOfCandidateInArray) + " to:" + newQuantizedCount)
 

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
@@ -21,7 +21,7 @@
 package org.idio.dbpedia.spotlight.stores
 
 
-import org.dbpedia.spotlight.db.memory.{ MemoryResourceStore, MemoryStore, MemoryCandidateMapStore }
+import org.dbpedia.spotlight.db.memory.{MemorySurfaceFormStore, MemoryResourceStore, MemoryStore, MemoryCandidateMapStore}
 import java.io.{ File, FileInputStream }
 import Array.concat
 import org.dbpedia.spotlight.model.SurfaceForm
@@ -35,8 +35,8 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
 
   quantizedCountStore = countStore
 
-  def this(pathtoFolder: String, resStore: MemoryResourceStore, countStore: CustomQuantiziedCountStore) {
-    this(MemoryStore.loadCandidateMapStore(new FileInputStream(new File(pathtoFolder, "candmap.mem")), resStore, countStore.quantizedStore),
+  def this(pathtoFolder: String, resStore: MemoryResourceStore, sfStore: MemorySurfaceFormStore, countStore: CustomQuantiziedCountStore) {
+    this(MemoryStore.loadCandidateMapStore(new FileInputStream(new File(pathtoFolder, "candmap.mem")), resStore, sfStore, countStore.quantizedStore),
                                            pathtoFolder, resStore, countStore)
   }
 

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomCandidateMapStore.scala
@@ -161,6 +161,23 @@ class CustomCandidateMapStore(var candidateMap: MemoryCandidateMapStore,
     return false
   }
 
+  def changePercentageOfContextVector(surfaceFormID: Int, dbpediaId: Int, surfaceFormCounts:Int, percentageOfVector: Double): Unit ={
+
+    def getCandidateSupport( surfaceFormCounts:Int, percentageOfVector: Double): Int = {
+      val numerator = (surfaceFormCounts + 3)
+      val denominator = (1-(2*(percentageOfVector - 0.1)))/(5*(percentageOfVector-0.1))
+      val candidateSupport = (numerator/ math.pow(math.E, denominator)) - 3
+      candidateSupport.toInt
+    }
+
+    val indexOfCandidateInArray = this.candidateMap.candidates(surfaceFormID).indexWhere { case (x) => x == dbpediaId }
+    val candidateCount = getCandidateSupport(surfaceFormCounts, percentageOfVector)
+
+    val newQuantizedCount:Short = getQuantiziedCounts(candidateCount)
+
+    this.candidateMap.candidateCounts(surfaceFormID)(indexOfCandidateInArray) = newQuantizedCount
+  }
+
   /*
   * Increments the candidates Counts for a given surfaceForm and candidate
   * */

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomContextStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomContextStore.scala
@@ -57,6 +57,10 @@ class CustomContextStore(val pathtoFolder: String,
   * */
   def addContext(dbpediaResourceID: Int, tokenID: Int, count: Int) {
     // check if the token is already in the context, if so dont do anything.
+    if(this.contextStore.tokens(dbpediaResourceID)==null && this.contextStore.tokens(dbpediaResourceID)==null) {
+      this.contextStore.tokens(dbpediaResourceID) = Array[Int]()
+      this.contextStore.counts(dbpediaResourceID) = Array[Short]()
+    }
     if (!(this.contextStore.tokens(dbpediaResourceID) contains tokenID)) {
       val quantiziedCount:Short = getQuantiziedCounts(count)
       this.contextStore.counts(dbpediaResourceID) = this.contextStore.counts(dbpediaResourceID) :+ quantiziedCount

--- a/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomContextStore.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/stores/CustomContextStore.scala
@@ -57,7 +57,7 @@ class CustomContextStore(val pathtoFolder: String,
   * */
   def addContext(dbpediaResourceID: Int, tokenID: Int, count: Int) {
     // check if the token is already in the context, if so dont do anything.
-    if(this.contextStore.tokens(dbpediaResourceID)==null && this.contextStore.tokens(dbpediaResourceID)==null) {
+    if(this.contextStore.tokens(dbpediaResourceID) == null && this.contextStore.tokens(dbpediaResourceID) == null) {
       this.contextStore.tokens(dbpediaResourceID) = Array[Int]()
       this.contextStore.counts(dbpediaResourceID) = Array[Short]()
     }

--- a/src/main/scala/org/idio/dbpedia/spotlight/utils/CommandLineParser.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/utils/CommandLineParser.scala
@@ -116,7 +116,8 @@ class CommandLineParser {
 
     val associationCommand = getSimpleCommand("association", "surfaceforms and candidate topics commands")
     associationCommand.children(
-      getCommandSingleArg("remove", "file with pairs(topic-surfaceForm)", "remove associations between sf and topics")
+      getCommandSingleArg("remove", "file with pairs(topic-surfaceForm)", "remove associations between sf and topics"),
+      getCommandSingleArg("percentage-context-vector", "file with pairs(topic-surfaceForm-%context vector)", "% of context vector used when matching entities")
     )
 
     val contextCommand =  getSimpleCommand("context", "context vectors commands")

--- a/src/main/scala/org/idio/dbpedia/spotlight/utils/CommandLineParser.scala
+++ b/src/main/scala/org/idio/dbpedia/spotlight/utils/CommandLineParser.scala
@@ -117,7 +117,7 @@ class CommandLineParser {
     val associationCommand = getSimpleCommand("association", "surfaceforms and candidate topics commands")
     associationCommand.children(
       getCommandSingleArg("remove", "file with pairs(topic-surfaceForm)", "remove associations between sf and topics"),
-      getCommandSingleArg("percentage-context-vector", "file with pairs(topic-surfaceForm-%context vector)", "% of context vector used when matching entities")
+      getCommandSingleArg("percentage-context-vector", "file with Triples(topic-surfaceForm-%context vector)", "% of context vector used when matching entities")
     )
 
     val contextCommand =  getSimpleCommand("context", "context vectors commands")


### PR DESCRIPTION
Connected to idio/playground/issues/45

**ps: remember this is public** 

Adds:
- `sh target/bin/model-editor association percentage-context-vector path/to/model path/to/changes.tsv`
- each line in `changes.tsv` looks like:  `topic\tsf\t%_of_context_vector`.  
- i.e: `Yuki_(singer)<tab>Yuko<tab>0.2`.

Notes: 
- it will increase/decrease associtation support(pairCount)
- I limited it, so that support can never be above SF annotated count.

---

Gotta:
- Check this through rendang
- Make sure prev context vectors are still alright https://github.com/idio/spotlight/issues/70
